### PR TITLE
(CI)Thread sanitizer + Data race prevention

### DIFF
--- a/EssentialFeed/CI.xctestplan
+++ b/EssentialFeed/CI.xctestplan
@@ -4,7 +4,8 @@
       "id" : "2001B5AC-9788-466B-97C4-AAAF2F7E9C5A",
       "name" : "Test Scheme Action",
       "options" : {
-        "testExecutionOrdering" : "random"
+        "testExecutionOrdering" : "random",
+        "threadSanitizerEnabled" : true
       }
     }
   ],

--- a/EssentialFeed/EssentialFeedTests/Feed API/URLSessionHTTPClientTests.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed API/URLSessionHTTPClientTests.swift
@@ -180,7 +180,6 @@ class URLSessionHTTPClientTests: XCTestCase {
         }
         
         override class func canInit(with request: URLRequest) -> Bool {
-            requestObserver?(request)
             return true
         }
         
@@ -189,6 +188,10 @@ class URLSessionHTTPClientTests: XCTestCase {
         }
         
         override func startLoading() {
+            if let requestObserver = URLProtocolStub.requestObserver {
+                client?.urlProtocolDidFinishLoading(self)
+                return requestObserver(request)
+            }
             
             if let data = URLProtocolStub.stub?.data {
                 client?.urlProtocol(self, didLoad: data)


### PR DESCRIPTION
- Adding thread sanitizer option when running tests with the CI scheme.
- Prevent data race by finishing loading before test methods finish.